### PR TITLE
chore: add tailwind directives support for vscode

### DIFF
--- a/.vscode/css_custom_data.json
+++ b/.vscode/css_custom_data.json
@@ -1,0 +1,35 @@
+{
+  "atDirectives": [
+    {
+      "description": "Use `@apply` to inline any existing utility classes into your own custom CSS. This is useful when you need to write custom CSS (like to override the styles in a third-party library) but still want to work with your design tokens and use the same syntax you're used to using in your HTML.",
+      "name": "@apply",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#apply"
+        }
+      ]
+    },
+    {
+      "description": "Use the `@layer` directive to tell Tailwind which \"bucket\" a set of custom styles belong to. Valid layers are `base`, `components`, and `utilities`.",
+      "name": "@layer",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#responsive"
+        }
+      ]
+    },
+    {
+      "description": "Use the `@tailwind` directive to insert Tailwind's `base`, `components`, `utilities` and `variants` styles into your CSS.",
+      "name": "@tailwind",
+      "references": [
+        {
+          "name": "Tailwind Documentation",
+          "url": "https://tailwindcss.com/docs/functions-and-directives#tailwind"
+        }
+      ]
+    }
+  ],
+  "version": 1.1
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "css.customData": [".vscode/css_custom_data.json"]
+}


### PR DESCRIPTION
This pull request adds [Tailwind CSS Directives](https://tailwindcss.com/docs/functions-and-directives#directives) support for [VS Code](https://code.visualstudio.com/).

**Before**

![1](https://user-images.githubusercontent.com/82393815/154771998-beaa4311-6930-4e5e-84cd-0b9c2b164897.png)

**After**

![2](https://user-images.githubusercontent.com/82393815/154772023-ef0e5e4c-3f4c-4085-a379-a35b420aee41.png)